### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -1,5 +1,9 @@
 name: Dependency Updates
 
+permissions:
+  contents: read
+  issues: write
+
 on:
   schedule:
     # Run weekly on Mondays at 9 AM UTC


### PR DESCRIPTION
Potential fix for [https://github.com/i-marsh/zwave-lock/security/code-scanning/9](https://github.com/i-marsh/zwave-lock/security/code-scanning/9)

To resolve the issue, explicitly declare a `permissions` block in your workflow file. Given both jobs use `actions/github-script` to create and comment on issues, the jobs require `contents: read` (to check out code, though technically this could also be omitted for pure issue jobs) and `issues: write` to interact with issues. The `permissions` block should be added at the workflow root, which will apply to both jobs unless a job-level override is needed. Add the block near the top for clarity, following the `name` (line 1) and before or just after the `on:` block.  
No additional methods, imports, or file definitions are required—just a change in the YAML permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
