### PR TITLE
fix(security): add npm overrides to enforce minimum safe transitive dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,11 @@
     "@types/express": "^5.0.6",
     "@types/node": "^25.0.3",
     "typescript": "^5.9.3"
+  },
+  "overrides": {
+    "qs": ">=6.14.0",
+    "flatted": ">=3.3.2",
+    "brace-expansion": ">=1.1.13",
+    "ajv": ">=6.14.0"
   }
 }


### PR DESCRIPTION
## Summary

Adds `overrides` to `package.json` to explicitly pin minimum safe versions for transitive dependencies with known security vulnerabilities.

## Vulnerabilities addressed

| Package | Advisory | Severity | Safe version |
|---------|----------|----------|-------------|
| `qs` | Prototype pollution / ReDoS | High | `>=6.14.0` |
| `flatted` | Unbounded recursion DoS ([GHSA-25h7-pfq9-p65f](https://github.com/advisories/GHSA-25h7-pfq9-p65f)) | High | `>=3.3.2` |
| `brace-expansion` | Zero-step sequence ReDoS ([GHSA-f886-m6hf-6m8v](https://github.com/advisories/GHSA-f886-m6hf-6m8v)) | Moderate | `>=1.1.13` |
| `ajv` | ReDoS with `$data` option ([GHSA-2g4f-4pwh-qvx6](https://github.com/advisories/GHSA-2g4f-4pwh-qvx6)) | Moderate | `>=6.14.0` |

## Why overrides (not lockfile-only)

PR #66 fixed these via a lockfile-only patch, which works but is fragile — a fresh `npm install` (e.g., in a new CI environment or after deleting `node_modules`) could regenerate the lockfile and potentially drift back to vulnerable versions. The `overrides` field enforces minimum safe versions **declaratively** in `package.json`, so they apply to any regenerated lockfile.

## Verification

```
$ npm audit
found 0 vulnerabilities
```

Closes #56