### PR TITLE
fix: return HTTP 503 from /health when Z-Wave driver is not ready

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -66,9 +66,12 @@ app.get('/health', (req: Request, res: Response) => {
     connected: false,
     ready: false
   };
-  
-  res.json({ 
-    status: 'ok',
+
+  const healthy = driver !== null && driver.ready;
+  const httpStatus = healthy ? 200 : 503;
+
+  res.status(httpStatus).json({
+    status: healthy ? 'ok' : 'error',
     server: 'running',
     driver: driverStatus,
     uptime: process.uptime(),


### PR DESCRIPTION
## Problem

The `/health` endpoint always returned HTTP 200 with `status: 'ok'`, even when the Z-Wave driver was `null` or `driver.ready` was `false`. The server appeared healthy to external monitors even when it couldn't process Z-Wave commands.

This violates the `MODULE_CONTRACT` expected by the compendium module manager, which treats any non-2xx response as unhealthy.

## Change

- **HTTP 200** — driver is connected **and** `driver.ready === true`
- **HTTP 503** — driver is `null` **or** `driver.ready === false`
- Response body shape is unchanged (`status`, `server`, `driver`, `uptime`, `timestamp`); `status` field is set to `'error'` on 503

## Before

```json
HTTP 200
{ "status": "ok", "server": "running", "driver": { "connected": false, "ready": false }, ... }
```

## After (driver not ready)

```json
HTTP 503
{ "status": "error", "server": "running", "driver": { "connected": false, "ready": false }, ... }
```